### PR TITLE
Update to confirm compatability of Big Sur

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ English/[中文](README-CN.md)
 
 **BIOS Version** : 1.2.0
 
-**macOS Version**: macOS Catalina 10.15.7 / Big Sur Beta10
+**macOS Version**: macOS Catalina 10.15.7 / Big Sur 11.0.1
 
 ![hackintosh](./screenshot/hackintosh2.png)
 


### PR DESCRIPTION
Can confirm the 4K config works on Big Sur 11.0.1. Presumably transfers to normal FHD config. 

See: https://www.reddit.com/r/hackintosh/comments/k8md5n/dell_xps_9300_opencore/